### PR TITLE
テスト名の日本語化

### DIFF
--- a/src/flask1/test_app.py
+++ b/src/flask1/test_app.py
@@ -1,29 +1,36 @@
 import pytest
+
 from flask1 import create_app
+
 
 @pytest.fixture
 def app():
-    app = create_app({'TESTING' : True})
+    app = create_app({"TESTING": True})
 
     return app
+
 
 @pytest.fixture
 def client(app):
     return app.test_client()
 
-def test_hello(client):
+
+def test_helloエンドポイントにアクセスした場合文字列が返る(client):
     rv = client.get("/")
-    assert "Hello Flask!" == rv.data.decode('utf8')
+    assert "Hello Flask!" == rv.data.decode("utf8")
+
 
 @pytest.mark.parametrize(
     [
         "name",
     ],
     [
-        pytest.param("ogawa"),
-        pytest.param("higashi")
+        pytest.param("ogawa", id="name = ogawa"),
+        pytest.param("higashi", id="name = higashi"),
     ],
 )
-def test_name(client, name):
+def test_helloエンドポイントに名前をつけた場合その名前が入った文字列が返る(
+    client, name
+):
     rv = client.get(f"/hello/{name}")
-    assert f"Hello {name}" == rv.data.decode('utf8')
+    assert f"Hello {name}" == rv.data.decode("utf8")


### PR DESCRIPTION
## 目的
テスト名が暗号化されていると、認知不可が高いため日本語で表示したい。

## やったこと
- テスト名の日本語化

## やらなかったこと
- パラメタライズテストの日本語化

## 参考文献
- https://zenn.dev/tanny/articles/cdb555d6124a2a
- https://qiita.com/gimKondo/items/d7a874a97af1ad93052a
